### PR TITLE
fix: Correct Slack notification webhook configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -605,8 +605,9 @@ jobs:
       if: always()
       continue-on-error: true
       uses: 8398a7/action-slack@v3
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
-        webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
         status: custom
         custom_payload: |
           {


### PR DESCRIPTION
- Fixed Slack action to use env variable instead of webhook_url parameter
- The 8398a7/action-slack@v3 action expects SLACK_WEBHOOK_URL as env variable
- Webhook URL is now properly passed via env section