### PR TITLE
Release v3.2.1 - Keyword link updates and URL improvements

### DIFF
--- a/84em-local-pages.php
+++ b/84em-local-pages.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: 84EM Local Pages Generator
  * Description: Generates SEO-optimized Local Pages for each US state using Claude AI. Includes WP-CLI testing framework.
- * Version: 3.2.0
+ * Version: 3.2.1
  * Author: 84EM
  * Requires at least: 6.8
  * Requires PHP: 8.2
@@ -12,7 +12,7 @@
 defined( 'ABSPATH' ) or die;
 
 // Define plugin constants
-const EIGHTYFOUREM_LOCAL_PAGES_VERSION = '3.2.0';
+const EIGHTYFOUREM_LOCAL_PAGES_VERSION = '3.2.1';
 
 // Load Composer autoloader
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the 84EM Local Pages Generator plugin will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2025-08-18
+
+### Added
+- **Keyword Link Update Command**: New `--update-keyword-links` command to refresh service keyword links without API calls
+  - Updates keyword links in all existing pages when `KeywordsProvider` URLs change
+  - Strips existing keyword links and reprocesses with current URLs
+  - Supports `--states-only` flag to update only state pages
+  - Shows progress bar with detailed statistics (updated/skipped/errors)
+  - Preserves all other content including city links and WordPress block structure
+  - No Claude API key required - works entirely with existing content
+
+### Changed
+- **KeywordsProvider URLs**: Updated service keyword mappings to use more specific URLs (Commit ae1f988)
+  - `custom plugin development` → `/services/custom-wordpress-plugin-development/`
+  - `white-label development` → `/services/white-label-wordpress-development-for-agencies/`
+  - Added new multi-word keywords with proper URL mappings
+  - All keywords now point to appropriate service-specific pages
+
 ## [3.2.0] - 2025-08-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,6 +307,10 @@ wp 84em local-pages --generate-index
 # Generate XML sitemap (no API key required)
 wp 84em local-pages --generate-sitemap
 
+# Update keyword links in existing pages (no API key required)
+wp 84em local-pages --update-keyword-links                    # All pages
+wp 84em local-pages --update-keyword-links --states-only      # States only
+
 # Regenerate LD-JSON schemas without touching content (no API key required)
 wp 84em local-pages --regenerate-schema                    # All pages
 wp 84em local-pages --regenerate-schema --states-only      # States only
@@ -412,6 +416,20 @@ The `--generate-sitemap` command creates XML sitemaps. This command:
 - **No API calls**: Generates XML using WordPress permalink data
 - **Includes All Pages**: Both state and city pages in sitemap
 - **Static output**: Creates `sitemap-local.xml` in WordPress root directory
+
+### Keyword Link Updates
+The `--update-keyword-links` command refreshes all keyword and location links in existing pages. This command:
+- **Does not require Claude API key**: Works with existing page content
+- **No API calls**: Reprocesses existing content with current keyword mappings
+- **Use Case**: Update links when KeywordsProvider URLs change
+- **Process**: 
+  1. Strips existing auto-generated keyword and location links
+  2. Reprocesses content with ContentProcessor using latest keywords
+  3. Preserves user-added links and content structure
+- **Options**:
+  - `--update-keyword-links`: Updates all state and city pages
+  - `--update-keyword-links --states-only`: Updates state pages only
+- **Performance**: Uses progress bar and batch processing for efficiency
 
 ## Health Check Endpoint
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This plugin creates unique, locally-focused landing pages for WordPress developm
 - **XML Sitemap Generation**: Generate XML sitemaps for all local pages with WP-CLI
 - **Index Page Generation**: Create or update a master index page with alphabetized state list
 - **Schema Regeneration**: Fix LD-JSON schema issues without regenerating page content
+- **Keyword Link Updates**: Update service keyword links when URLs change without API calls
 
 ## Requirements
 
@@ -240,6 +241,15 @@ wp 84em local-pages --generate-index
 wp 84em local-pages --generate-sitemap
 ```
 
+**Update Keyword Links (Refresh service keyword links without API calls):**
+```bash
+# Update keyword links in all pages
+wp 84em local-pages --update-keyword-links
+
+# Update keyword links in state pages only
+wp 84em local-pages --update-keyword-links --states-only
+```
+
 **Regenerate LD-JSON Schemas (Fix schema issues without regenerating content):**
 ```bash
 # All pages
@@ -366,7 +376,7 @@ https://84em.com/wordpress-development-services-texas/dallas/
 ```php
 'model' => 'claude-sonnet-4-20250514'
 'max_tokens' => 4000
-'timeout' => 60 seconds
+'timeout' => 600 seconds
 'rate_limit' => 1 second delay between requests
 ```
 

--- a/src/Cli/CommandHandler.php
+++ b/src/Cli/CommandHandler.php
@@ -124,6 +124,11 @@ class CommandHandler {
                 return;
             }
 
+            if ( isset( $assoc_args['update-keyword-links'] ) ) {
+                $this->generateCommand->handleUpdateKeywordLinks( $args, $assoc_args );
+                return;
+            }
+
             // Handle delete operations (don't require API key)
             if ( isset( $assoc_args['delete'] ) ) {
                 $this->generateCommand->handleDelete( $args, $assoc_args );
@@ -481,7 +486,7 @@ class CommandHandler {
             'state', 'city', 'test', 'suite', 'generate-all', 'update-all',
             'states-only', 'complete', 'set-api-key', 'validate-api-key',
             'generate-sitemap', 'generate-index', 'regenerate-schema',
-            'delete', 'update', 'help', 'all'
+            'update-keyword-links', 'delete', 'update', 'help', 'all'
         ];
         
         $unrecognized = [];
@@ -661,7 +666,7 @@ class CommandHandler {
         
         // Check for states-only with inappropriate commands
         if ( isset( $assoc_args['states-only'] ) ) {
-            $valid_with_states_only = ['generate-all', 'update-all', 'regenerate-schema'];
+            $valid_with_states_only = ['generate-all', 'update-all', 'regenerate-schema', 'update-keyword-links'];
             $has_valid_command = false;
             
             foreach ( $valid_with_states_only as $valid_cmd ) {
@@ -673,10 +678,11 @@ class CommandHandler {
             
             if ( ! $has_valid_command ) {
                 throw new \Exception(
-                    "--states-only can only be used with --generate-all, --update-all, or --regenerate-schema\n" .
+                    "--states-only can only be used with --generate-all, --update-all, --regenerate-schema, or --update-keyword-links\n" .
                     "Examples:\n" .
                     "  wp 84em local-pages --generate-all --states-only\n" .
-                    "  wp 84em local-pages --update-all --states-only\n"
+                    "  wp 84em local-pages --update-all --states-only\n" .
+                    "  wp 84em local-pages --update-keyword-links --states-only\n"
                 );
             }
         }
@@ -729,6 +735,8 @@ class CommandHandler {
         WP_CLI::line( '  --delete --state="State" --city="City"  Delete specific city' );
         WP_CLI::line( '  --generate-sitemap         Generate XML sitemap for all local pages' );
         WP_CLI::line( '  --generate-index           Generate index page with all locations' );
+        WP_CLI::line( '  --update-keyword-links     Update keyword links in all existing pages' );
+        WP_CLI::line( '  --update-keyword-links --states-only  Update keyword links in state pages only' );
         WP_CLI::line( '  --regenerate-schema        Regenerate schema markup for all pages' );
         WP_CLI::line( '' );
         WP_CLI::line( 'EXAMPLES:' );


### PR DESCRIPTION
## Added
- New --update-keyword-links command to refresh service keyword links without API calls
  - Updates all existing pages when KeywordsProvider URLs change
  - Strips old links and reprocesses with current URL mappings
  - Supports --states-only flag for targeted updates
  - No Claude API key required

## Changed
- Updated KeywordsProvider URLs to use more specific service pages (commit ae1f988)
  - custom plugin development → /services/custom-wordpress-plugin-development/
  - white-label development → /services/white-label-wordpress-development-for-agencies/
  - Added new multi-word keywords with proper URL mappings

🤖 Generated with Claude Code