### PR TITLE
v3.22.1 - Local page schema pricing repositioning

### DIFF
--- a/84em-local-pages.php
+++ b/84em-local-pages.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: 84EM Local Pages Generator
  * Description: Generates SEO-optimized Local Pages for each US state using Claude AI. Includes WP-CLI testing framework.
- * Version: 3.22.0
+ * Version: 3.22.1
  * Author: 84EM
  * Author URI: https://84em.com/
  * Plugin URI: https://github.com/84emllc/84em-local-pages/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the 84EM Local Pages Generator plugin will be documented 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.22.1] - 2026-02-24
+
+### Changed
+- **Schema**: Switch local page pricing from fixed `price` to `minPrice` and `priceRange` from `$150-225/hour` to `$$$` in schema.org structured data
+
 ## [3.22.0] - 2026-02-14
 
 ### Changed

--- a/src/Schema/SchemaGenerator.php
+++ b/src/Schema/SchemaGenerator.php
@@ -99,7 +99,7 @@ class SchemaGenerator implements SchemaGeneratorInterface {
                     '@type'         => 'Offer',
                     'priceSpecification' => [
                         '@type'       => 'PriceSpecification',
-                        'price'       => '150',
+                        'minPrice'    => '150',
                         'priceCurrency' => 'USD',
                         'unitText'    => 'per hour',
                     ],
@@ -110,7 +110,7 @@ class SchemaGenerator implements SchemaGeneratorInterface {
                 'name'        => '84EM WordPress Development',
                 'description' => "WordPress development agency founded in 2012, specializing in custom plugin development, AI integration, and agency partnerships. Over 30 years of web development experience since 1995. Serving {$state} businesses from Cedar Rapids, Iowa headquarters.",
                 'url'         => site_url( '/' ),
-                'priceRange'  => '$150-225/hour',
+                'priceRange'  => '$$$',
                 'areaServed'  => [
                     '@type' => 'State',
                     'name'  => $state,
@@ -221,7 +221,7 @@ class SchemaGenerator implements SchemaGeneratorInterface {
                     '@type'         => 'Offer',
                     'priceSpecification' => [
                         '@type'       => 'PriceSpecification',
-                        'price'       => '150',
+                        'minPrice'    => '150',
                         'priceCurrency' => 'USD',
                         'unitText'    => 'per hour',
                     ],


### PR DESCRIPTION
## Summary
- Switch local page schema pricing from fixed `price` to `minPrice` for state and city pages
- Update `priceRange` from `$150-225/hour` to `$$$` (schema.org standard notation)

## Test plan
- [ ] Verify schema.org output on state pages shows `minPrice` instead of `price`
- [ ] Verify `priceRange` shows `$$$` on state pages
- [ ] Verify city page schema shows `minPrice`